### PR TITLE
 Resources should be closed

### DIFF
--- a/mbhd-swing/src/main/java/org/multibit/hd/ui/services/ExternalDataListeningService.java
+++ b/mbhd-swing/src/main/java/org/multibit/hd/ui/services/ExternalDataListeningService.java
@@ -178,23 +178,16 @@ public class ExternalDataListeningService extends AbstractService {
 
     Preconditions.checkNotNull(message, "'message' must be present");
 
-    try {
-      Socket clientSocket = new Socket(
-        InetAddress.getLoopbackAddress(),
-        MULTIBIT_HD_NETWORK_SOCKET
-      );
-
-      try (OutputStream out = clientSocket.getOutputStream()) {
-
+    try(Socket clientSocket = new Socket(
+            InetAddress.getLoopbackAddress(),
+            MULTIBIT_HD_NETWORK_SOCKET); 
+        OutputStream out = clientSocket.getOutputStream()) {
+      
         // Write out the raw external data for parsing by the other instance
         out.write(MESSAGE_START.getBytes(Charsets.UTF_8));
         out.write(message.getBytes(Charsets.UTF_8));
         out.write(MESSAGE_END.getBytes(Charsets.UTF_8));
-
-        out.close();
-      }
-      clientSocket.close();
-
+        
     } catch (IOException e) {
       log.error(e.getMessage(), e);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “ Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.
